### PR TITLE
adds nix flake config file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758029226,
+        "narHash": "sha256-TjqVmbpoCqWywY9xIZLTf6ANFvDCXdctCjoYuYPYdMI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "08b8f92ac6354983f5382124fef6006cade4a1c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+  outputs = {nixpkgs, ...}: let
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed
+      (system: function nixpkgs.legacyPackages.${system});
+  in {
+    formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          corepack
+          nodejs_24
+          yarn
+        ];
+      };
+    });
+  };
+}


### PR DESCRIPTION
‼️ PR title should follow conventional commits (https://conventionalcommits.org) ‼️

### 🔗 Linked issue

!-- Please ensure there is an open issue and mention its number as #123 --

### 📚 Description

!-- Describe your changes in detail --
!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" --

### 📖 Updated documentation

!-- Make sure to mention what you changed in the documentation in regards of the new change made in PR --
!-- Updating documentation is not necessary, but is heavily encouraged for bigger/crucial changes --
*No response*


### TBD

Adds a flake.nix file to manage the project's development environment.
The flake configuration includes:

- nixpkgs from unstable channel (gets pkg updates fastest)
- development shell with corepack@latest, node@24 and yarn@latest
- nix formatter using nixfmt-rfc-style

This makes it easy - for nix users - to set up a development environment.